### PR TITLE
Had to fix indexing error, when some indices were not correctly inter…

### DIFF
--- a/dpks/differential_testing.py
+++ b/dpks/differential_testing.py
@@ -167,7 +167,7 @@ class DifferentialTest:
 
         quantitative_data.quantitative_data.obs = sorted_annotations
         quantitative_data.quantitative_data.X = quantitative_data.quantitative_data[
-            sorted_annotations.index.astype(int), :
+            sorted_annotations.index, :
         ].X.copy()
 
         return quantitative_data


### PR DESCRIPTION
…preted as integers initially


This was causing failure in differential expression.

Now the indices are inferred from the sorted DF that stores the metadata of the AnnData object