### PR TITLE
Fixed parallel loop in quanitfying proteins

### DIFF
--- a/dpks/annotate_proteins.py
+++ b/dpks/annotate_proteins.py
@@ -1,18 +1,22 @@
+from typing import List
+
 from Bio import SeqIO
 import gzip
+
 
 def parse_fasta(fasta):
     fasta_dict = {}
     for record in SeqIO.parse(fasta, "fasta"):
         id = record.id
-        accession = id.split('|')[1]
-        name = id.split('|')[2]
+        accession = id.split("|")[1]
+        name = id.split("|")[2]
         fasta_dict[accession] = name
-    return fasta_dict 
+    return fasta_dict
+
 
 def fasta_to_dict(fasta_path: str) -> dict:
     fasta_dict = {}
-    if fasta_path.endswith('gz'):
+    if fasta_path.endswith("gz"):
         with gzip.open(fasta_path, "rt") as handle:
             fasta_dict = parse_fasta(handle)
     else:
@@ -20,11 +24,10 @@ def fasta_to_dict(fasta_path: str) -> dict:
     return fasta_dict
 
 
-
-def get_protein_labels(accessions : list[str], fasta_path : str) -> list[str]:
+def get_protein_labels(accessions: List[str], fasta_path: str) -> List[str]:
     """Maps UniProt ID (accession) to more common names. P69905 --> HBA_HUMAN
     Args:
-        accessions list[str]: Input protein list 
+        accessions list[str]: Input protein list
         fasta_path str: fasta file path used for mapping
     Returns:
         protein_labels list[str]: More common protein names. If accession not in human_proteome.gz, use accession.
@@ -32,15 +35,10 @@ def get_protein_labels(accessions : list[str], fasta_path : str) -> list[str]:
     fasta_dict = fasta_to_dict(fasta_path)
     protein_labels = []
     for accession in accessions:
-        try: 
+        try:
             protein_label = fasta_dict[accession]
         except KeyError:
             # If accession not in fasta file, put accession instead of protein label
             protein_label = accession
         protein_labels.append(protein_label)
     return protein_labels
-
-
-
-    
-    

--- a/dpks/quant_matrix.py
+++ b/dpks/quant_matrix.py
@@ -49,7 +49,6 @@ class QuantMatrix:
         design_matrix_file: Union[str, pd.DataFrame],
         annotation_fasta_file: str = None,
         build_quant_graph: bool = False,
-
     ) -> None:
         """init"""
 
@@ -91,11 +90,13 @@ class QuantMatrix:
         row_obs = quantification_file.drop(
             list(design_matrix_file["sample"]), axis=1
         ).set_index(np.arange(self.num_rows, dtype=int).astype(str))
-        
+
         if annotation_fasta_file is not None:
 
-            row_obs["ProteinLabel"] = get_protein_labels(row_obs['Protein'], annotation_fasta_file)
-            
+            row_obs["ProteinLabel"] = get_protein_labels(
+                row_obs["Protein"], annotation_fasta_file
+            )
+
         self.quantitative_data = ad.AnnData(
             quantitative_data,
             obs=row_obs,
@@ -106,13 +107,11 @@ class QuantMatrix:
         if build_quant_graph:
 
             pass
-        
-
 
     @property
     def proteins(self) -> List[str]:
         """returns unique list of Proteins.
-        
+
         >>> sorted(quant_matrix.proteins)[40:42]
         ['sp|G5E8V9|ARFP1_MOUSE', 'sp|O08528|HXK2_MOUSE']
 
@@ -236,6 +235,10 @@ class QuantMatrix:
 
             filtered_data = filtered_data[
                 ~filtered_data.obs["Protein"].str.contains("contam")
+            ].copy()
+
+            filtered_data = filtered_data[
+                ~filtered_data.obs["Protein"].str.contains("cont_crap")
             ].copy()
 
         self.num_rows = len(filtered_data)


### PR DESCRIPTION
Numba typed lists are not thread safe, so indicating the size and datatypes to hold data and then reformatting the returned results seems to have worked.

Formatted with black.

Includes some changes to the annotation function